### PR TITLE
Fix exit issues and schema names with - in the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ Usage examples
                 key=org.gnome.desktop.wm.keybindings.panel-main-menu
                 value="@as []"
 
+Or explicitly define scheme and key isntead of using dash to seperate them, useful when the schema name includeds dashes.
+
+    - name: do not remember mount password
+      gsetting: user=jistr
+                schema=org.gnome.shell.remember
+                key=mount-password
+                value=false
+
+    - name: change dash to dock klick action
+      gsetting: user=jistr
+                schema=org.gnome.shell.extensions.dash-to-dock
+                key=click-action
+                value="previews"
+
 Be careful with string values, which should be passed into GSetting
 single-quoted. You'll need to quote the value twice in YAML:
 


### PR DESCRIPTION
On latest Ansible version the module was failing to do a proper
exit this commit fixes that.

It is now also possible to call the lib with optional scheme value,
previously the lib would split the key value (x.x.x-y-y-y)to
get the scheme so the scheme was x.x.x and the key was y-y-y
this doesn't hold when an application has - inside the scheme
name , to make it work with this kind of schemes,
now one can call the module with explicitly adding scheme and key.